### PR TITLE
fallback readline to pyreadline for Windows.

### DIFF
--- a/moveit_commander/bin/moveit_commander_cmdline.py
+++ b/moveit_commander/bin/moveit_commander_cmdline.py
@@ -2,7 +2,10 @@
 
 import roslib
 import rospy
-import readline
+try:
+    import readline
+except ImportError:
+    import pyreadline as readline
 import sys
 import os
 import signal


### PR DESCRIPTION
The replacement of readline for Windows is pyreadline.