### PR TITLE
[moveit_ros_perception] Fix C3848 error

### DIFF
--- a/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
+++ b/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
@@ -105,7 +105,7 @@ private:
 
   struct SortBodies
   {
-    bool operator()(const SeeShape& b1, const SeeShape& b2)
+    bool operator()(const SeeShape& b1, const SeeShape& b2) const
     {
       if (b1.volume > b2.volume)
         return true;


### PR DESCRIPTION
Recently the Azure DevOps build machine has upgraded the visual studio 2019 from `v16.1.6` to `v16.2.0`. And in the newer toolchain, a build break manifests as below:

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.22.27905\include\xtree(1730): error C3848: expression having type 'const point_containment_filter::ShapeMask::SortBodies' would lose some const-volatile qualifiers in order to call 'bool point_containment_filter::ShapeMask::SortBodies::operator ()(const point_containment_filter::ShapeMask::SeeShape &,const point_containment_filter::ShapeMask::SeeShape &)'
```

As the error suggests, the `xtree` requires the `point_containment_filter::ShapeMask::SortBodies::operator ()` to be `const`.

NOTE: The same incident manifested in other project after vs2019 update. https://github.com/winlibs/libiconv/issues/9#issuecomment-517924525